### PR TITLE
Removed page transition for faster load and less scroll problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "next": "^8.1.0",
     "next-apollo": "^2.1.0",
     "next-ga": "^2.3.4",
-    "next-page-transitions": "^1.0.0-beta.2",
     "next-redux-wrapper": "^3.0.0-alpha.2",
     "next-with-apollo": "^3.4.0",
     "nprogress": "^0.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
 import { ApolloProvider } from 'react-apollo'
 import { PersistGate } from 'redux-persist/integration/react'
-import { PageTransition } from 'next-page-transitions'
 import withGA from 'next-ga'
 import withShopify from '../lib/shopify'
 import Head from '../components/Head'
@@ -32,13 +31,7 @@ class MyApp extends App {
         <Provider store={store}>
           <ApolloProvider client={apollo}>
             <Header>
-              <PageTransition
-                timeout={300}
-                classNames='page-transition'
-                monkeyPatchScrolling
-              >
-                <Component {...pageProps} key={router.route} />
-              </PageTransition>
+              <Component {...pageProps} key={router.route} />
             </Header>
           </ApolloProvider>
         </Provider>


### PR DESCRIPTION
Scroll was starting in the middle of the page sometimes disabling page fade transition will solve this.

We get some 2kb less on first load for that.